### PR TITLE
Add script to upgrade openmediavault distinctively

### DIFF
--- a/run.d/81-apt-dist-upgrade-omv
+++ b/run.d/81-apt-dist-upgrade-omv
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+. $(dirname $(readlink -f "$0"))/../inc/localvars
+. $(dirname $(readlink -f "$0"))/../inc/omvvars
+
+relname=$(echo ${OMV_UPGRADE_RELEASENAME} | tr "[:upper:]" "[:lower:]" | tr -d "[:space:]")
+
+apt-get dist-upgrade -t ${relname} ${THIS_APT_UPGRADE_OPTIONS} || apt-get install -f
+
+exit 0


### PR DESCRIPTION
Because in later OMV releases the openmediavault package repositories are no
longer pinned with a high value (995) by default setting APT::Default-Release
pins the Debian repository higher. So some dependencies for omv5 might not be
installed and omv5 will not be upgraded. With this step we do a distinct
upgrade attempt.

Fixes #7