### PR TITLE
Mark docker, plex, duplicati as manually installed

### DIFF
--- a/pre.d/49-mark-manual
+++ b/pre.d/49-mark-manual
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+PACKAGES="
+plexmediaserver
+duplicati
+docker-ce
+"
+
+apt-mark manual ${PACKAGES}
+
+exit 0


### PR DESCRIPTION
These packages have been integrated into the OMV5 GUI. The related plugins
must be removed. But these packages should not be removed with them.

resolves #9

kudos to @ryecoaaron
https://forum.openmediavault.org/index.php?thread/37269-upgrade-scripts-for-non-interactive-major-release-upgrades-2-3-3-4-4-5/&postID=261265#post261265