### PR TITLE
Test if share is mounted before trying to remount it read-only

### DIFF
--- a/pre.d/10-remount-ro
+++ b/pre.d/10-remount-ro
@@ -19,6 +19,8 @@ if [ -n "${media}" ]
 then
 	for d in ${media}
 	do
+		# Test if share is mounted, otherwise do nothing for this share.
+		test -n "$(cat /proc/mounts | awk -v share=${d} '$2 == share { print $2 }')" || continue
 		echo "Re-mounting ${d} read-only"
 		mount -v -o remount,ro $d
 	done


### PR DESCRIPTION
If the share hasn't been mounted for whatever reason the script might fail too. But we want to catch only errors when the share is mounted and cannot be remounted read-only.

fixes #14