### PR TITLE
Iterate over grub-pc's install_device multiselect key

### DIFF
--- a/check.d/90-grub
+++ b/check.d/90-grub
@@ -12,7 +12,7 @@ do
 	test -n "${dev}" || continue
 
 	if [ ! -b "${dev}" ] ||
-	   [ -z "$(dd bs=512 count=1 if=${dev} 2>/dev/null | strings | grep -w GRUB)" ]
+	   [ -z "$(dd bs=512 count=1 if=${dev} 2>/dev/null | hexdump -C | grep -w GRUB)" ]
 	then
 		echo "The debconf database contains an entry for the device to install GRUB to,"
 		echo "which either doesn't exist, or doesn't contain an existing GRUB entry:"

--- a/check.d/90-grub
+++ b/check.d/90-grub
@@ -15,7 +15,10 @@ do
 	   [ -z "$(dd bs=512 count=1 if=${dev} 2>/dev/null | strings | grep -w GRUB)" ]
 	then
 		echo "The debconf database contains an entry for the device to install GRUB to,"
-		echo "which either doesn't exist, or doesn't contain an existing GRUB entry."
+		echo "which either doesn't exist, or doesn't contain an existing GRUB entry:"
+		echo
+		echo "The entry is: ${dev}"
+		echo
 		echo "To prevent you from being unable to boot your system the script will abort now."
 		echo "See https://bugs.debian.org/966575 for details."
 		echo

--- a/check.d/90-grub
+++ b/check.d/90-grub
@@ -2,20 +2,26 @@
 
 set -e
 
-boot="$(debconf-show grub-pc | awk '$2 == "grub-pc/install_devices:" {print $3}')"
+boot="$(debconf-show grub-pc | grep -wi install_devices | awk -F: '{print $2}' | tr -d ',')"
 
-test -n "${boot}" || exit 0
+# if key is empty there is nothing to do
+test -n "${boot}" || exit 0 
 
-if [ ! -b "${boot}" ] ||
-   [ -z "$(dd bs=512 count=1 if=${boot} 2>/dev/null | strings | grep -w GRUB)" ]
-then
-	echo "The debconf database contains an entry for the device to install GRUB to,"
-	echo "which either doesn't exist, or doesn't contain an existing GRUB entry."
-	echo "To prevent you from being unable to boot your system the script will abort now."
-	echo "See https://bugs.debian.org/966575 for details."
-	echo
-	echo "Please run 'sudo dpkg-reconfigure -plow grub-pc' and select the correct device."
-	exit 1
-fi
+for dev in ${boot}
+do
+	test -n "${dev}" || continue
+
+	if [ ! -b "${dev}" ] ||
+	   [ -z "$(dd bs=512 count=1 if=${dev} 2>/dev/null | strings | grep -w GRUB)" ]
+	then
+		echo "The debconf database contains an entry for the device to install GRUB to,"
+		echo "which either doesn't exist, or doesn't contain an existing GRUB entry."
+		echo "To prevent you from being unable to boot your system the script will abort now."
+		echo "See https://bugs.debian.org/966575 for details."
+		echo
+		echo "Please run 'sudo dpkg-reconfigure -plow grub-pc' and select the correct device."
+		exit 1
+	fi
+done
 
 exit 0

--- a/check.d/90-grub
+++ b/check.d/90-grub
@@ -17,7 +17,7 @@ do
 		echo "The debconf database contains an entry for the device to install GRUB to,"
 		echo "which either doesn't exist, or doesn't contain an existing GRUB entry:"
 		echo
-		echo "The entry is: ${dev}"
+		echo "The entry is: ${dev} ($(readlink -f ${dev}))"
 		echo
 		echo "To prevent you from being unable to boot your system the script will abort now."
 		echo "See https://bugs.debian.org/966575 for details."


### PR DESCRIPTION
The `grub-pc/install_device` debconf key can contain multiple entries. This fix checks all of them and also replaces strings by hexdump.