### PR TITLE
Don't compress downloaded indexes

### DIFF
--- a/inc/localvars
+++ b/inc/localvars
@@ -2,7 +2,7 @@
 
 THIS_APT_APT_CONF=${THIS_APT_APT_CONF:-"/etc/apt/apt.conf"}
 THIS_APT_INSTALL_OPTIONS=${THIS_APT_INSTALL_OPTIONS:-"-y --no-install-recommends --no-install-suggests"}
-THIS_APT_UPDATE_OPTIONS=${THIS_APT_UPDATE_OPTIONS:-""}
+THIS_APT_UPDATE_OPTIONS=${THIS_APT_UPDATE_OPTIONS:-"-o Acquire::GzipIndexes=false"}
 THIS_APT_UPGRADE_OPTIONS=${THIS_APT_UPGRADE_OPTIONS:-"${THIS_APT_INSTALL_OPTIONS} -u -o Dpkg::Options::=--force-confdef -o DPkg::Options::=--force-confold"}
 THIS_APT_SOURCES_LIST=${THIS_APT_SOURCES_LIST:-"/etc/apt/sources.list"}
 THIS_APT_SOURCES_LIST_D=${THIS_APT_SOURCES_LIST_D:-"${THIS_APT_SOURCES_LIST}.d"}


### PR DESCRIPTION
apt-show-versions cannot handle compressed index files. So make sure they are
not compressed. See https://bugs.debian.org/617856.

fixes #25 